### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: "v4.4.0"
+  rev: "v4.5.0"
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -24,7 +24,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/asottile/setup-cfg-fmt
-  rev: "v2.4.0"
+  rev: "v2.5.0"
   hooks:
   - id: setup-cfg-fmt
 
@@ -34,25 +34,25 @@ repos:
   - id: isort
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: "v3.13.0"
+  rev: "v3.15.0"
   hooks:
   - id: pyupgrade
     args: ["--py36-plus"]
 
 - repo: https://github.com/psf/black
-  rev: "23.9.1"
+  rev: "23.10.1"
   hooks:
   - id: black
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: "v1.5.1"
+  rev: "v1.6.1"
   hooks:
     - id: mypy
       files: src
       stages: [manual]
 
 - repo: https://github.com/hadialqattan/pycln
-  rev: "v2.2.2"
+  rev: "v2.3.0"
   hooks:
   - id: pycln
     args: ["--all"]
@@ -83,7 +83,7 @@ repos:
     stages: [manual]
 
 - repo: https://github.com/codespell-project/codespell
-  rev: "v2.2.5"
+  rev: "v2.2.6"
   hooks:
   - id: codespell
     args: ["-L", "nd,unparseable,compiletime"]


### PR DESCRIPTION
updates:
- [github.com/pre-commit/pre-commit-hooks: v4.4.0 → v4.5.0](pre-commit/pre-commit-hooks@v4.4.0...v4.5.0)
- [github.com/asottile/setup-cfg-fmt: v2.4.0 → v2.5.0](asottile/setup-cfg-fmt@v2.4.0...v2.5.0)
- [github.com/asottile/pyupgrade: v3.13.0 → v3.15.0](asottile/pyupgrade@v3.13.0...v3.15.0)
- [github.com/psf/black: 23.9.1 → 23.10.1](psf/black@23.9.1...23.10.1)
- [github.com/pre-commit/mirrors-mypy: v1.5.1 → v1.6.1](pre-commit/mirrors-mypy@v1.5.1...v1.6.1)
- [github.com/hadialqattan/pycln: v2.2.2 → v2.3.0](hadialqattan/pycln@v2.2.2...v2.3.0)
- [github.com/codespell-project/codespell: v2.2.5 → v2.2.6](codespell-project/codespell@v2.2.5...v2.2.6)