### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
   - id: setup-cfg-fmt
 
 - repo: https://github.com/PyCQA/isort
-  rev: "5.12.0"
+  rev: "5.13.2"
   hooks:
   - id: isort
 
@@ -40,12 +40,12 @@ repos:
     args: ["--py36-plus"]
 
 - repo: https://github.com/psf/black
-  rev: "23.11.0"
+  rev: "23.12.1"
   hooks:
   - id: black
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: "v1.7.1"
+  rev: "v1.8.0"
   hooks:
     - id: mypy
       files: src
@@ -102,7 +102,7 @@ repos:
   - id: rst-inline-touching-normal
 
 - repo: https://github.com/pre-commit/mirrors-prettier
-  rev: "v4.0.0-alpha.3"
+  rev: "v4.0.0-alpha.8"
   hooks:
     - id: prettier
       types_or: [json]


### PR DESCRIPTION
updates:
- [github.com/psf/black: 23.10.1 → 23.11.0](psf/black@23.10.1...23.11.0)
- [github.com/pre-commit/mirrors-mypy: v1.6.1 → v1.7.1](pre-commit/mirrors-mypy@v1.6.1...v1.7.1)
- [github.com/hadialqattan/pycln: v2.3.0 → v2.4.0](hadialqattan/pycln@v2.3.0...v2.4.0)
- [github.com/pre-commit/mirrors-prettier: v3.0.3 → v4.0.0-alpha.3](pre-commit/mirrors-prettier@v3.0.3...v4.0.0-alpha.3)