### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,14 +42,14 @@ repos:
         args: [--prose-wrap=always]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.2.1"
+    rev: "v0.3.4"
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.8.0"
+    rev: "v1.9.0"
     hooks:
       - id: mypy
         files: src|tests
@@ -63,7 +63,7 @@ repos:
       - id: codespell
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: "v0.9.0.6"
+    rev: "v0.10.0.1"
     hooks:
       - id: shellcheck
 
@@ -81,7 +81,7 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.28.0
+    rev: 0.28.1
     hooks:
       - id: check-dependabot
       - id: check-github-workflows


### PR DESCRIPTION
updates:
- [github.com/astral-sh/ruff-pre-commit: v0.2.1 → v0.3.4](astral-sh/ruff-pre-commit@v0.2.1...v0.3.4)
- [github.com/pre-commit/mirrors-mypy: v1.8.0 → v1.9.0](pre-commit/mirrors-mypy@v1.8.0...v1.9.0)
- [github.com/shellcheck-py/shellcheck-py: v0.9.0.6 → v0.10.0.1](shellcheck-py/shellcheck-py@v0.9.0.6...v0.10.0.1)
- [github.com/python-jsonschema/check-jsonschema: 0.28.0 → 0.28.1](python-jsonschema/check-jsonschema@0.28.0...0.28.1)

based on https://github.com/legend-exp/legend-pygeom-optics/pull/52