### PR TITLE
switch pen and pen_top to be before the detector name

### DIFF
--- a/src/l200geom/hpge_strings.py
+++ b/src/l200geom/hpge_strings.py
@@ -172,7 +172,7 @@ def _place_hpge_string(
             list(pen_rot),
             [x_pos, y_pos, z_unit_pen],
             pen_plate,
-            det_unit.name + "_pen",
+            "pen_" + det_unit.name,
             b.mother_lv,
             b.registry,
         )
@@ -186,7 +186,7 @@ def _place_hpge_string(
                 [0, 0, string_rot],
                 [x_pos, y_pos, z_pos_det + det_unit.height + 1.5 / 2],
                 pen_plate,
-                det_unit.name + "_pen_top",
+                "pen_top_" + det_unit.name,
                 b.mother_lv,
                 b.registry,
             )


### PR DESCRIPTION
This would make specifying all the Germanium detectors or PEN plates much easier with wildcards.
We might still want to think of better names @gipert / @ManuelHu ?