### PR TITLE
Update B99000A.json to fix the groove

### DIFF
--- a/src/l200geom/configs/dummy_geom/B99000A.json
+++ b/src/l200geom/configs/dummy_geom/B99000A.json
@@ -14,8 +14,8 @@
     "groove": {
       "depth_in_mm": 2.0,
       "radius_in_mm": {
-        "outer": 10.0,
-        "inner": 12.0
+        "outer": 12.0,
+        "inner": 10.0
       }
     },
     "pp_contact": {


### PR DESCRIPTION
Old version of the test data had a bug for the groove, was fixed here https://github.com/legend-exp/legend-testdata/commit/2553a28262a9447a2f61b1ad428b1b5a44546cd7
Maybe we can avoid the duplication somehow?