### PR TITLE
ruff: enable pep8-naming lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ extend-select = [
   "EXE",      # flake8-executable
   "NPY",      # NumPy specific rules
   "PD",       # pandas-vet
+  "N",        # pep8-naming
 ]
 ignore = [
   "PLR09",    # Too many <...>

--- a/src/l200geom/materials/__init__.py
+++ b/src/l200geom/materials/__init__.py
@@ -30,31 +30,31 @@ class OpticalMaterialRegistry:
             self._elements[symbol] = (self._elements_cb[symbol])()
         return self._elements[symbol]
 
-    def _add_element(self, name: str, symbol: str, Z: int, A: float) -> None:
+    def _add_element(self, name: str, symbol: str, z: int, a: float) -> None:
         """Lazily define an element on the current registry."""
         assert symbol not in self._elements_cb
         self._elements_cb[symbol] = lambda: g4.ElementSimple(
-            name=name, symbol=symbol, Z=Z, A=A, registry=self.g4_registry
+            name=name, symbol=symbol, Z=z, A=a, registry=self.g4_registry
         )
 
     def _define_elements(self) -> None:
         """Lazily define all used elements."""
-        self._add_element(name="Hydrogen", symbol="H", Z=1, A=1.00794)
-        self._add_element(name="Carbon", symbol="C", Z=6, A=12.011)
-        self._add_element(name="Nitrogen", symbol="N", Z=7, A=14.01)
-        self._add_element(name="Oxygen", symbol="O", Z=8, A=16.00)
-        self._add_element(name="Fluorine", symbol="F", Z=9, A=19.00)
-        self._add_element(name="Silicon", symbol="Si", Z=14, A=28.09)
-        self._add_element(name="argon", symbol="Ar", Z=18, A=39.95)
-        self._add_element(name="Chromium", symbol="Cr", Z=24, A=51.9961)
-        self._add_element(name="Manganese", symbol="Mn", Z=25, A=54.93805)
-        self._add_element(name="Iron", symbol="Fe", Z=26, A=55.845)
-        self._add_element(name="Indium", symbol="In", Z=49, A=114.82)
-        self._add_element(name="Cobalt", symbol="Co", Z=27, A=58.9332)
-        self._add_element(name="Nickel", symbol="Ni", Z=28, A=58.6934)
-        self._add_element(name="Copper", symbol="Cu", Z=29, A=63.55)
-        self._add_element(name="Tantalum", symbol="Ta", Z=73, A=180.94)
-        self._add_element(name="Gold", symbol="Au", Z=79, A=196.967)
+        self._add_element(name="Hydrogen", symbol="H", z=1, a=1.00794)
+        self._add_element(name="Carbon", symbol="C", z=6, a=12.011)
+        self._add_element(name="Nitrogen", symbol="N", z=7, a=14.01)
+        self._add_element(name="Oxygen", symbol="O", z=8, a=16.00)
+        self._add_element(name="Fluorine", symbol="F", z=9, a=19.00)
+        self._add_element(name="Silicon", symbol="Si", z=14, a=28.09)
+        self._add_element(name="argon", symbol="Ar", z=18, a=39.95)
+        self._add_element(name="Chromium", symbol="Cr", z=24, a=51.9961)
+        self._add_element(name="Manganese", symbol="Mn", z=25, a=54.93805)
+        self._add_element(name="Iron", symbol="Fe", z=26, a=55.845)
+        self._add_element(name="Indium", symbol="In", z=49, a=114.82)
+        self._add_element(name="Cobalt", symbol="Co", z=27, a=58.9332)
+        self._add_element(name="Nickel", symbol="Ni", z=28, a=58.6934)
+        self._add_element(name="Copper", symbol="Cu", z=29, a=63.55)
+        self._add_element(name="Tantalum", symbol="Ta", z=73, a=180.94)
+        self._add_element(name="Gold", symbol="Au", z=79, a=196.967)
 
     @property
     def liquidargon(self) -> g4.Material:


### PR DESCRIPTION
we already follow this style, so we can also check for it to ensure consitency.