### PR TITLE
cli|config unification for geometry, better assembly parameter handling

### DIFF
--- a/docs/source/calibration.md
+++ b/docs/source/calibration.md
@@ -69,7 +69,7 @@ source.
 extra_source:
   # x, y, z coordinates. z extends positively downwards, z = 0 is a source
   # "screwed into the top plate" (i.e. z is the coordinate of the top face of the
-  # volume the source wopuld normally be screwed into.
+  # volume the source would normally be screwed into.
   position_in_mm: [0, 0, 700]
   # to identify in geometry, this produces a volume `source_inner{name}`
   name: "_central"

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -25,6 +25,10 @@ After installation, the CLI utility `legend-pygeom-l200` is provided on your
 PATH. This CLI utility is the primary way to interact with this package. For
 now, you can find usage docs by running `legend-pygeom-l200 -h`.
 
+Some geometry options can both be set on the CLI utility and on the config file.
+Those are described in [the docs on runtime configuration](runtime-cfg), but the
+descriptions similarly apply to the CLI options.
+
 ```{toctree}
 :maxdepth: 2
 

--- a/docs/source/runtime-cfg.md
+++ b/docs/source/runtime-cfg.md
@@ -4,6 +4,53 @@ For often-changing details of the geometry are configured using a runtime
 configuration JSON file. This file is specified using the `--config $FILE`
 parameter.
 
+## Geometry options
+
+geometry options are both available in the CLI interface and the config file
+interface. Provided CLI options override the values from the config file.
+
+```{important}
+Always use `fiber_modules: detailed` (in the config file) or
+`--fiber-modules detailed` (on CLI) for optical simulations.
+
+**The simplified geometry has a different (and certainly wrong) light-guiding
+efficiency** - it is only suitable for visualisation or simulations not requiring
+full optical physics.
+```
+
+example config (not the default values!):
+
+```yaml
+# select parts of the geometry to be built.
+assemblies:
+  - fibers
+  - strings
+
+# Select the fiber shroud model, either coarse segments or single fibers.
+fiber_modules: detailed # or "segmented"
+
+# Select the PMT configuration of the muon veto.
+pmt_config: LEGEND200 # or "GERDA"
+
+# If true, build from public testdata only.
+public_geom: false
+```
+
+The list of assemblies provided in the `assmblies` config option or the
+`--assemblies` CLI option can be either:
+
+- a list of assemblies to build: `strings,calibration` will build the argon
+  cryostat (this is always bullt), the HPGe strings and the calibration system
+  only.
+- a list of operations modifying the default assembly list: `+watertank` will
+  build all default assemblies (i.e. the argon cryostat and anything in it), and
+  dd also the muon veto watertank.
+
+Specifying assemblies in the config file works similarly, but requires the list
+to be passed as an actual JSON/YAML list instead of a comma-delimited string.
+
+## configurable subsystems
+
 Detailed information about the configurable subsystems is available:
 
 ```{toctree}

--- a/src/l200geom/cli.py
+++ b/src/l200geom/cli.py
@@ -62,11 +62,17 @@ def dump_gdml_cli() -> None:
 
     # options for geometry generation.
     geom_opts = parser.add_argument_group("geometry options")
+    extra_assemblies = set(core.DEFINED_ASSEMBLIES) - set(core.DEFAULT_ASSEMBLIES)
     geom_opts.add_argument(
         "--assemblies",
         action="store",
-        default=",".join(core.DEFINED_ASSEMBLIES),
-        help="""Select the assemblies to generate in the output. (default: %(default)s)""",
+        default=",".join(core.DEFAULT_ASSEMBLIES),
+        type=_parse_assemblies,
+        help=(
+            f"""Select the assemblies to generate in the output.
+            (default: %(default)s;
+            additionally available: {",".join(extra_assemblies)})"""
+        ),
     )
     geom_opts.add_argument(
         "--fiber-modules",
@@ -124,7 +130,7 @@ def dump_gdml_cli() -> None:
             meshconfig.setGlobalMeshSliceAndStack(100)
 
     registry = core.construct(
-        assemblies=[a for a in args.assemblies.split(",") if a != ""],
+        assemblies=args.assemblies,
         pmt_configuration_mv=args.pmt_config,
         use_detailed_fiber_model=args.fiber_modules == "detailed",
         config=config,
@@ -152,3 +158,7 @@ def dump_gdml_cli() -> None:
         from pygeomtools import viewer
 
         viewer.visualize(registry, vis_scene)
+
+
+def _parse_assemblies(arg: str):
+    return [a for a in arg.split(",") if a != ""]

--- a/src/l200geom/core.py
+++ b/src/l200geom/core.py
@@ -19,10 +19,10 @@ log = logging.getLogger(__name__)
 
 configs = TextDB(resources.files("l200geom") / "configs" / "extra_meta")
 
-DEFAULT_ASSEMBLIES = ["wlsr", "strings", "calibration", "fibers", "top"]
-DEFINED_ASSEMBLIES = [*DEFAULT_ASSEMBLIES, "watertank"]
+DEFAULT_ASSEMBLIES = {"wlsr", "strings", "calibration", "fibers", "top"}
+DEFINED_ASSEMBLIES = DEFAULT_ASSEMBLIES | {"watertank"}
 
-PMT_CONFIGURATIONS = ["LEGEND200", "GERDA"]
+PMT_CONFIGURATIONS = {"LEGEND200", "GERDA"}
 
 
 class InstrumentationData(NamedTuple):
@@ -49,7 +49,7 @@ class InstrumentationData(NamedTuple):
 
 
 def construct(
-    assemblies: list[str] = DEFINED_ASSEMBLIES,
+    assemblies: list[str] | set[str] = DEFINED_ASSEMBLIES,
     pmt_configuration_mv: str = "LEGEND200",
     use_detailed_fiber_model: bool = False,
     config: dict | None = None,

--- a/src/l200geom/core.py
+++ b/src/l200geom/core.py
@@ -19,7 +19,8 @@ log = logging.getLogger(__name__)
 
 configs = TextDB(resources.files("l200geom") / "configs" / "extra_meta")
 
-DEFINED_ASSEMBLIES = ["wlsr", "strings", "calibration", "fibers", "top", "watertank"]
+DEFAULT_ASSEMBLIES = ["wlsr", "strings", "calibration", "fibers", "top"]
+DEFINED_ASSEMBLIES = [*DEFAULT_ASSEMBLIES, "watertank"]
 
 PMT_CONFIGURATIONS = ["LEGEND200", "GERDA"]
 

--- a/tests/test_cfg/cfg_geom.yaml
+++ b/tests/test_cfg/cfg_geom.yaml
@@ -1,0 +1,4 @@
+fiber_modules: detailed
+assemblies:
+  - wlsr
+  - fibers

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,25 +2,42 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 
 def test_cli():
-    from l200geom import core
     from l200geom.cli import _parse_cli_args
+    from l200geom.core import DEFAULT_ASSEMBLIES
 
     p = Path(__file__).parent.resolve() / "test_cfg"
 
     args, config = _parse_cli_args([])
     assert args.fiber_modules == "segmented"
-    assert args.assemblies == core.DEFAULT_ASSEMBLIES
+    assert args.assemblies == DEFAULT_ASSEMBLIES
 
     args, config = _parse_cli_args(["--config", str(p / "cfg_geom.yaml")])
     assert args.fiber_modules == "detailed"
-    assert args.assemblies == ["wlsr", "fibers"]
+    assert args.assemblies == {"wlsr", "fibers"}
     args, config = _parse_cli_args(["--config", str(p / "cfg_geom.yaml"), "--fiber-modules", "segmented"])
     assert args.fiber_modules == "segmented"
-    assert args.assemblies == ["wlsr", "fibers"]
+    assert args.assemblies == {"wlsr", "fibers"}
     args, config = _parse_cli_args(
         ["--config", str(p / "cfg_geom.yaml"), "--assemblies", "strings,calibration"]
     )
     assert args.fiber_modules == "detailed"
-    assert args.assemblies == ["strings", "calibration"]
+    assert args.assemblies == {"strings", "calibration"}
+
+
+def test_assemblies():
+    from l200geom.cli import _parse_assemblies
+    from l200geom.core import DEFAULT_ASSEMBLIES
+
+    assert _parse_assemblies(None) == DEFAULT_ASSEMBLIES
+    assert _parse_assemblies("watertank,calibration") == {"watertank", "calibration"}
+    assert _parse_assemblies(["watertank", "calibration"]) == {"watertank", "calibration"}
+    assert _parse_assemblies("+watertank") == DEFAULT_ASSEMBLIES | {"watertank"}
+    assert _parse_assemblies("+watertank,-fibers") == (DEFAULT_ASSEMBLIES | {"watertank"}) - {"fibers"}
+    assert _parse_assemblies(["+watertank", "-fibers"]) == (DEFAULT_ASSEMBLIES | {"watertank"}) - {"fibers"}
+
+    with pytest.raises(ValueError, match="all or no assemblies can be prefixed"):
+        _parse_assemblies("+watertank,fibers")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_cli():
+    from l200geom import core
+    from l200geom.cli import _parse_cli_args
+
+    p = Path(__file__).parent.resolve() / "test_cfg"
+
+    args, config = _parse_cli_args([])
+    assert args.fiber_modules == "segmented"
+    assert args.assemblies == core.DEFAULT_ASSEMBLIES
+
+    args, config = _parse_cli_args(["--config", str(p / "cfg_geom.yaml")])
+    assert args.fiber_modules == "detailed"
+    assert args.assemblies == ["wlsr", "fibers"]
+    args, config = _parse_cli_args(["--config", str(p / "cfg_geom.yaml"), "--fiber-modules", "segmented"])
+    assert args.fiber_modules == "segmented"
+    assert args.assemblies == ["wlsr", "fibers"]
+    args, config = _parse_cli_args(
+        ["--config", str(p / "cfg_geom.yaml"), "--assemblies", "strings,calibration"]
+    )
+    assert args.fiber_modules == "detailed"
+    assert args.assemblies == ["strings", "calibration"]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,8 +20,9 @@ def test_import():
 def conctruct_fiber_variants():
     from l200geom import core
 
-    reg_detailed = core.construct(use_detailed_fiber_model=True, public_geometry=public_geom)
-    reg_segmented = core.construct(use_detailed_fiber_model=False, public_geometry=public_geom)
+    assemblies = core.DEFINED_ASSEMBLIES
+    reg_detailed = core.construct(assemblies, use_detailed_fiber_model=True, public_geometry=public_geom)
+    reg_segmented = core.construct(assemblies, use_detailed_fiber_model=False, public_geometry=public_geom)
 
     return reg_detailed, reg_segmented
 


### PR DESCRIPTION
* geometry options (`--assemblies`, `--fiber-modules`, `--pmt-config`, `--public-geom`) can now also be set via the config file
* CLI options take precendence before config options
* assemblies can now also be specified by adding/removing from the default set of assemblies
* the watertank is not longer part of the default assembly set

fixes #42 