### PR TITLE
Add scaling factors per channel

### DIFF
--- a/src/l200geom/fibers.py
+++ b/src/l200geom/fibers.py
@@ -326,7 +326,10 @@ class ModuleFactoryBase(ABC):
             f"bsurface_lar_{sipm_name}",
             self.b.mother_pv,
             sipm_pv,
-            self.b.materials.surfaces.to_sipm_silicon,
+            self.b.materials.surfaces.to_sipm_silicon(
+                self.b.runtime_config,
+                sipm_name,
+            ),
             self.b.registry,
         )
 
@@ -741,7 +744,10 @@ class ModuleFactorySingleFibers(ModuleFactoryBase):
                 f"bsurface_lar_{mod.channel_bottom_name}",
                 self.b.mother_pv,
                 sipm_pv,
-                self.b.materials.surfaces.to_sipm_silicon,
+                self.b.materials.surfaces.to_sipm_silicon(
+                    self.b.runtime_config,
+                    mod.channel_bottom_name,
+                ),
                 self.b.registry,
             )
 
@@ -1065,7 +1071,10 @@ class ModuleFactorySegment(ModuleFactoryBase):
                 f"bsurface_lar_{mod.channel_bottom_name}",
                 self.b.mother_pv,
                 sipm_pv,
-                self.b.materials.surfaces.to_sipm_silicon,
+                self.b.materials.surfaces.to_sipm_silicon(
+                    self.b.runtime_config,
+                    mod.channel_bottom_name,
+                ),
                 self.b.registry,
             )
 

--- a/src/l200geom/materials/surfaces.py
+++ b/src/l200geom/materials/surfaces.py
@@ -112,13 +112,13 @@ class OpticalSurfaceRegistry:
         if not runtime_config.get("use_pde_curve", True):
             eff = np.ones_like(λ)
 
-        # Check if scaling_factors exist and contain this channel
-        sf = runtime_config.get("scaling_factors", {})
+        # Check if efficiencies exist and contain this channel
+        efficiencies = runtime_config.get("efficiencies", {})
 
         # get the factor for this channel, default to 1.0
-        scale_factor = sf.get(channel_name, 1.0)
+        eff_factor = efficiencies.get(channel_name, 1.0)
 
-        eff = eff * scale_factor  # scale channel-specific efficiency
+        eff = eff * eff_factor  # scale channel-specific efficiency
         eff = np.clip(eff, 0, 1)
 
         with u.context("sp"):

--- a/src/l200geom/materials/surfaces.py
+++ b/src/l200geom/materials/surfaces.py
@@ -109,7 +109,7 @@ class OpticalSurfaceRegistry:
         λ, eff = ketek_sipm_efficiency()
 
         # Check whether to use the KETEK efficiency curve. If not, use flat 1s.
-        if not runtime_config.get("use_pde_curve", False):
+        if not runtime_config.get("use_pde_curve", True):
             eff = np.ones_like(λ)
 
         # Check if scaling_factors exist and contain this channel

--- a/tests/test_scaling_factors.py
+++ b/tests/test_scaling_factors.py
@@ -10,10 +10,10 @@ from l200geom import core
 public_geom = os.getenv("LEGEND_METADATA", "") == ""
 
 
-def test_construct_with_scaling_factors():
+def test_construct_with_efficiencies():
     cfg = AttrsDict(
         {
-            "scaling_factors": AttrsDict({"S002": 0.5}),
+            "efficiencies": AttrsDict({"S002": 0.5}),
             "use_pde_curve": False,
         }
     )

--- a/tests/test_scaling_factors.py
+++ b/tests/test_scaling_factors.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+
+import numpy as np
+from dbetto import AttrsDict
+
+from l200geom import core
+
+public_geom = os.getenv("LEGEND_METADATA", "") == ""
+
+
+def test_construct_with_scaling_factors():
+    cfg = AttrsDict(
+        {
+            "scaling_factors": AttrsDict({"S002": 0.5}),
+            "use_pde_curve": False,
+        }
+    )
+
+    registry = core.construct(assemblies=["fibers"], config=cfg, public_geometry=public_geom)
+    assert "surface_to_sipm_silicon_S002_EFFICIENCY" in registry.defineDict
+
+    # Get the optical surface object
+    surf_obj = registry.defineDict["surface_to_sipm_silicon_S002_EFFICIENCY"]
+
+    # Read the efficiency property
+    eff_values = surf_obj.eval()[0, ::][1::2]
+
+    # Assert that all values are 0.5
+    assert np.allclose(eff_values, 0.5)


### PR DESCRIPTION
Options can be passed to runconfig file in order to add scaling factors per SiPM channel

- `use_pde_curve: False` to use nominal photo detection efficiency (PDE) curve with all values = 1.0, instead of KETEK PDE curve
- `scaling_factors`: path to yaml file with scaling factors per SiPM channel, like this
```
S037: 0.7143658055256549 
S055: 0.6850331898098314 
S073: 0.8939271618227485 
```
If a channel doesn't exist, scaling factor is set to 1.
Scaling factors are clipped at 1.