### PR TITLE
wlsr: switch to an implementation without surface overlaps

### DIFF
--- a/src/l200geom/wlsr.py
+++ b/src/l200geom/wlsr.py
@@ -46,7 +46,7 @@ def _construct_wlsr(
         "wlsr_ttx",
         wlsr_tpb_radius + wlsr_tpb_thickness,
         wlsr_tpb_radius + wlsr_tpb_thickness + wlsr_ttx_thickness,
-        wlsr_height - spacing,
+        wlsr_height - 2 * spacing,
         0,
         2 * pi,
         reg,


### PR DESCRIPTION
These changes are required to make the "geantino overlap check" pass. They should not change the macroscopic optical response.