### PR TITLE
hack to give an option to remove fiber support

### DIFF
--- a/src/l200geom/cli.py
+++ b/src/l200geom/cli.py
@@ -38,6 +38,7 @@ def dump_gdml_cli(argv: list[str] | None = None) -> None:
         assemblies=args.assemblies,
         pmt_configuration_mv=args.pmt_config,
         use_detailed_fiber_model=args.fiber_modules == "detailed",
+        remove_fiber_copper=args.remove_fiber_copper,
         config=config,
         public_geometry=args.public_geom,
     )
@@ -142,6 +143,13 @@ def _parse_cli_args(argv: list[str] | None = None) -> tuple[argparse.Namespace, 
         choices=("segmented", "detailed"),
         help=f"""Select the fiber shroud model, either coarse segments or single fibers. (default: {fiber_modules_default})""",
     )
+
+    geom_opts.add_argument(
+        "--remove-fiber-copper",
+        action="store_true",
+        default=None,
+        help="""Remove the fiber support copper which could currently cause some performance penalty.""",
+    )
     pmt_config_default = "LEGEND200"
     geom_opts.add_argument(
         "--pmt-config",
@@ -177,6 +185,7 @@ def _parse_cli_args(argv: list[str] | None = None) -> tuple[argparse.Namespace, 
     # also load geometry options from config file.
     _config_or_cli_arg(args, config, "assemblies", None)
     _config_or_cli_arg(args, config, "fiber_modules", fiber_modules_default)
+    _config_or_cli_arg(args, config, "remove_fiber_copper", False)
     _config_or_cli_arg(args, config, "pmt_config", pmt_config_default)
     _config_or_cli_arg(args, config, "public_geom", False)
 

--- a/src/l200geom/core.py
+++ b/src/l200geom/core.py
@@ -51,6 +51,7 @@ def construct(
     assemblies: list[str] | set[str] = DEFAULT_ASSEMBLIES,
     pmt_configuration_mv: str = "LEGEND200",
     use_detailed_fiber_model: bool = False,
+    remove_fiber_copper: bool = False,
     config: dict | None = None,
     public_geometry: bool = False,
 ) -> geant4.Registry:
@@ -165,7 +166,9 @@ def construct(
         top.place_top_plate(instr)
     if "fibers" in assemblies:
         hw_meta = lmeta.hardware.detectors.lar.fibers if lmeta is not None else dummy_geom.fibers
-        fibers.place_fiber_modules(hw_meta, instr, use_detailed_fiber_model)
+        fibers.place_fiber_modules(
+            hw_meta, instr, use_detailed_fiber_model, remove_fiber_copper=remove_fiber_copper
+        )
 
     _assign_common_copper_surface(instr)
 

--- a/src/l200geom/fibers.py
+++ b/src/l200geom/fibers.py
@@ -16,6 +16,7 @@ def place_fiber_modules(
     fiber_metadata: TextDB,
     b: core.InstrumentationData,
     use_detailed_fiber_model: bool = False,
+    remove_fiber_copper: bool = False,
 ) -> None:
     """Construct LEGEND-200 liquid argon instrumentation.
 
@@ -98,7 +99,7 @@ def place_fiber_modules(
         if mod.barrel == "inner":
             ib_factory.create_module(mod)
 
-    if any(mod.barrel == "outer" for mod in modules.values()):
+    if any(mod.barrel == "outer" for mod in modules.values()) and (not remove_fiber_copper):
         fiber_support_outer = get_fiber_support_outer(b)
         g4.PhysicalVolume(
             [0, 0, 0],
@@ -108,7 +109,7 @@ def place_fiber_modules(
             b.mother_lv,
             b.registry,
         )
-    if any(mod.barrel == "inner" for mod in modules.values()):
+    if any(mod.barrel == "inner" for mod in modules.values()) and (not remove_fiber_copper):
         fiber_support_inner = get_fiber_support_inner(b)
         g4.PhysicalVolume(
             [0, 0, 0],


### PR DESCRIPTION
Temporary solution that allows us to run L200 simulations where the fiber copper is not relevant.