### PR TITLE
feat: add HPGe simulated-vs-measured mass comparison plot

### DIFF
--- a/src/pygeoml200/__init__.py
+++ b/src/pygeoml200/__init__.py
@@ -2,5 +2,6 @@ from __future__ import annotations
 
 from pygeoml200._version import version as __version__
 from pygeoml200.core import construct
+from pygeoml200.hpge_mass_check import plot_hpge_mass_comparison
 
-__all__ = ["__version__", "construct"]
+__all__ = ["__version__", "construct", "plot_hpge_mass_comparison"]

--- a/src/pygeoml200/core.py
+++ b/src/pygeoml200/core.py
@@ -23,6 +23,9 @@ DEFINED_ASSEMBLIES = DEFAULT_ASSEMBLIES | {"watertank"}
 
 PMT_CONFIGURATIONS = {"LEGEND200", "GERDA"}
 
+# default metadata timestamp used to select the channel map and special-geometry metadata.
+DEFAULT_METADATA_TIMESTAMP = "20230311T235840Z"
+
 
 class InstrumentationData(NamedTuple):
     mother_lv: geant4.LogicalVolume
@@ -139,7 +142,7 @@ def construct(
         "displacement from cryostat center (positive to top): %f mm", top_plate_z_pos - array_total_height / 2
     )
 
-    timestamp = config.get("metadata_timestamp", "20230311T235840Z")
+    timestamp = config.get("metadata_timestamp", DEFAULT_METADATA_TIMESTAMP)
     if lmeta is None and "metadata_timestamp" in config:
         msg = "metadata_timestamp cannot be specified for public dummy geometry"
         raise ValueError(msg)

--- a/src/pygeoml200/hpge_mass_check.py
+++ b/src/pygeoml200/hpge_mass_check.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import contextlib
+import copy
+import logging
+from typing import TYPE_CHECKING
+
+import numpy as np
+from git import GitCommandError
+from legendmeta import LegendMetadata
+from pygeomhpges import make_hpge
+from pygeomtools.utils import load_dict_from_config
+
+from .core import DEFAULT_METADATA_TIMESTAMP
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+
+log = logging.getLogger(__name__)
+
+
+def plot_hpge_mass_comparison(
+    config: dict | None = None,
+    *,
+    allow_cylindrical_asymmetry: bool = True,
+    ax: Axes | None = None,
+) -> Axes:
+    """Plot the relative mass difference ``(MC - measured) / measured`` for each HPGe in the geometry.
+
+    The mass of each detector, built with :func:`pygeomhpges.make_hpge`, is compared to the measured mass
+    from the metadata and grouped by manufacturer. The axes drawn into are returned.
+
+    Parameters
+    ----------
+    config
+        the geometry configuration dictionary accepted by :func:`pygeoml200.core.construct` (real LEGEND
+        metadata is required).
+    allow_cylindrical_asymmetry
+        passed to :func:`pygeomhpges.make_hpge`; if ``False``, build detectors with the cylindrically
+        symmetric base class, ignoring non-symmetric features.
+    ax
+        a :class:`matplotlib.axes.Axes` to draw into. If ``None``, a new figure and axes are created.
+    """
+    import matplotlib.pyplot as plt
+
+    config = config if config is not None else {}
+
+    lmeta = None
+    with contextlib.suppress(GitCommandError):
+        lmeta = LegendMetadata(lazy=True)
+    if lmeta is None:
+        msg = "real LEGEND metadata is required for the HPGe mass comparison but could not be loaded"
+        raise RuntimeError(msg)
+
+    timestamp = config.get("metadata_timestamp", DEFAULT_METADATA_TIMESTAMP)
+    channelmap = load_dict_from_config(config, "channelmap", lambda: lmeta.channelmap(timestamp))
+    diodes = lmeta.hardware.detectors.germanium.diodes
+
+    # only consider the germanium detectors actually built into the geometry, i.e. the geds channels.
+    geds = channelmap.map("system", unique=False).get("geds", {})
+    names = sorted(ch.name for ch in geds.values())
+
+    colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+    group_color = {"Mirion": colors[0], "Ortec": colors[1]}
+
+    # group -> {detector name: relative mass difference in percent}
+    group_values: dict[str, dict[str, float]] = {}
+
+    for name in names:
+        meta = copy.deepcopy(diodes[name])
+
+        measured_mass = meta.production.get("mass_in_g")
+        if measured_mass is None:
+            log.warning("%s has no measured mass in metadata, skipping", name)
+            continue
+
+        # some detectors miss the enrichment value: fall back to a dummy value. The metadata stores it
+        # either as a plain number or as a {"val": ..., "unc": ...} mapping.
+        enrichment = meta.production.get("enrichment")
+        enrichment_val = enrichment.val if hasattr(enrichment, "val") else enrichment
+        if enrichment_val is None:
+            log.warning("%s has no enrichment in metadata, setting to dummy value 0.92", name)
+            meta.production.enrichment = 0.92
+
+        hpge = make_hpge(meta, None, allow_cylindrical_asymmetry)
+        sim_mass = hpge.mass.to("g").m
+
+        rel_diff = 100 * (sim_mass - measured_mass) / measured_mass
+
+        group = meta.production.manufacturer
+        group_values.setdefault(group, {})[name] = rel_diff
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=(16, 3))
+    assert ax is not None
+
+    for group, values in sorted(group_values.items()):
+        # keep one entry per detector name (NaN elsewhere) so all series share the same, ordered x axis.
+        y = [values.get(name, np.nan) for name in names]
+        ax.plot(names, y, "o", color=group_color.get(group, colors[2]), markersize=4, label=group)
+
+    ax.axhline(0, color="gray", linewidth=1.5, zorder=0)
+    ax.grid(visible=True)
+    ax.set_title("difference between simulated and measured HPGe mass")
+    ax.set_ylabel("(MC - measured) / measured [%]")
+    ax.tick_params(axis="x", labelrotation=90)
+    ax.legend(ncol=3)
+    return ax


### PR DESCRIPTION
## Summary

Adds `pygeoml200.plot_hpge_mass_comparison`, a validation helper that compares the simulated HPGe masses
(volumes built with `pygeomhpges.make_hpge`) against the measured masses stored in metadata, for the
detectors built into the geometry, grouped by manufacturer.

- accepts the same `config` dict as `core.construct` (honours `metadata_timestamp` and `channelmap`)
- exposes the `make_hpge` `allow_cylindrical_asymmetry` flag
- lifts the default metadata timestamp into a shared `core.DEFAULT_METADATA_TIMESTAMP` constant, reused by
  both `construct` and the new function

## Example

```python
import pygeoml200 as pg

ax = pg.plot_hpge_mass_comparison(config={"metadata_timestamp": "20250716T161517Z"})  # p15-p16
ax.figure.savefig("hpge-mass-comparison.pdf", bbox_inches="tight")
```

![HPGe simulated-vs-measured mass comparison, p15-p16](https://raw.githubusercontent.com/legend-exp/legend-pygeom-l200/ba6816a3073fcb7275bf6d25e36decb0f5c6eb4c/hpge-mass-comparison-p15.png)
