### PR TITLE
feat: support public geometry in HPGe mass comparison

### DIFF
--- a/src/pygeoml200/configs/dummy_geom/B99000A.json
+++ b/src/pygeoml200/configs/dummy_geom/B99000A.json
@@ -2,7 +2,8 @@
   "name": "B99000A",
   "type": "bege",
   "production": {
-    "manufacturer": "Test",
+    "manufacturer": "Ortec",
+    "mass_in_g": 860.0,
     "enrichment": {
       "val": 0.75,
       "unc": 0.05

--- a/src/pygeoml200/configs/dummy_geom/C99000A.json
+++ b/src/pygeoml200/configs/dummy_geom/C99000A.json
@@ -2,7 +2,8 @@
   "name": "C99000A",
   "type": "coax",
   "production": {
-    "manufacturer": "Test",
+    "manufacturer": "Mirion",
+    "mass_in_g": 2100.0,
     "enrichment": {
       "val": 0.75,
       "unc": 0.05

--- a/src/pygeoml200/configs/dummy_geom/P99000A.json
+++ b/src/pygeoml200/configs/dummy_geom/P99000A.json
@@ -2,7 +2,8 @@
   "name": "P99000A",
   "type": "ppc",
   "production": {
-    "manufacturer": "Test",
+    "manufacturer": "Ortec",
+    "mass_in_g": 835.0,
     "enrichment": {
       "val": 0.75,
       "unc": 0.05

--- a/src/pygeoml200/configs/dummy_geom/V99000A.json
+++ b/src/pygeoml200/configs/dummy_geom/V99000A.json
@@ -2,7 +2,8 @@
   "name": "V99000A",
   "type": "icpc",
   "production": {
-    "manufacturer": "Test",
+    "manufacturer": "Mirion",
+    "mass_in_g": 1220.0,
     "enrichment": {
       "val": 0.75,
       "unc": 0.05

--- a/src/pygeoml200/hpge_mass_check.py
+++ b/src/pygeoml200/hpge_mass_check.py
@@ -12,6 +12,7 @@ from pygeomhpges import make_hpge
 from pygeomtools.utils import load_dict_from_config
 
 from .core import DEFAULT_METADATA_TIMESTAMP
+from .metadata import PublicMetadataProxy
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -23,6 +24,7 @@ def plot_hpge_mass_comparison(
     config: dict | None = None,
     *,
     allow_cylindrical_asymmetry: bool = True,
+    public_geometry: bool = False,
     ax: Axes | None = None,
 ) -> Axes:
     """Plot the relative mass difference ``(MC - measured) / measured`` for each HPGe in the geometry.
@@ -33,11 +35,15 @@ def plot_hpge_mass_comparison(
     Parameters
     ----------
     config
-        the geometry configuration dictionary accepted by :func:`pygeoml200.core.construct` (real LEGEND
-        metadata is required).
+        the geometry configuration dictionary accepted by :func:`pygeoml200.core.construct`. If it carries a
+        truthy ``"public_geom"`` flag (or ``public_geometry`` is set), the public testdata metadata is used
+        instead of a real LEGEND metadata checkout.
     allow_cylindrical_asymmetry
         passed to :func:`pygeomhpges.make_hpge`; if ``False``, build detectors with the cylindrically
         symmetric base class, ignoring non-symmetric features.
+    public_geometry
+        force the use of the public testdata metadata, overriding the ``config["public_geom"]``
+        auto-detection. Mirrors the ``public_geometry`` argument of :func:`pygeoml200.core.construct`.
     ax
         a :class:`matplotlib.axes.Axes` to draw into. If ``None``, a new figure and axes are created.
     """
@@ -46,15 +52,23 @@ def plot_hpge_mass_comparison(
     config = config if config is not None else {}
 
     lmeta = None
-    with contextlib.suppress(GitCommandError):
-        lmeta = LegendMetadata(lazy=True)
+    public = public_geometry or bool(config.get("public_geom", False))
+    if not public:
+        with contextlib.suppress(GitCommandError):
+            lmeta = LegendMetadata(lazy=True)
+        if lmeta is None:
+            msg = "real LEGEND metadata is required for the HPGe mass comparison but could not be loaded"
+            raise RuntimeError(msg)
     if lmeta is None:
-        msg = "real LEGEND metadata is required for the HPGe mass comparison but could not be loaded"
-        raise RuntimeError(msg)
+        dummy_geom = PublicMetadataProxy()
 
     timestamp = config.get("metadata_timestamp", DEFAULT_METADATA_TIMESTAMP)
-    channelmap = load_dict_from_config(config, "channelmap", lambda: lmeta.channelmap(timestamp))
-    diodes = lmeta.hardware.detectors.germanium.diodes
+    channelmap = load_dict_from_config(
+        config,
+        "channelmap",
+        lambda: lmeta.channelmap(timestamp) if lmeta is not None else dummy_geom.chmap,
+    )
+    diodes = lmeta.hardware.detectors.germanium.diodes if lmeta is not None else dummy_geom.diodes
 
     # only consider the germanium detectors actually built into the geometry, i.e. the geds channels.
     geds = channelmap.map("system", unique=False).get("geds", {})

--- a/tests/test_hpge_mass.py
+++ b/tests/test_hpge_mass.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import matplotlib as mpl
+
+mpl.use("Agg")
+
+import numpy as np
+
+
+def test_public_hpge_mass_comparison():
+    # the public geometry must yield a non-empty, finite comparison without a metadata git checkout.
+    from pygeoml200 import plot_hpge_mass_comparison
+
+    ax = plot_hpge_mass_comparison({"public_geom": True})
+
+    finite = []
+    for line in ax.get_lines():
+        y = np.asarray(line.get_ydata(), dtype=float)
+        finite.extend(y[np.isfinite(y)])
+
+    # at least one plotted detector point (besides the y=0 reference line) with a finite value.
+    assert any(v != 0 for v in finite)
+    assert all(np.isfinite(v) for v in finite)
+
+
+def test_public_hpge_mass_comparison_keyword():
+    # the public_geometry keyword forces the testdata path, matching core.construct.
+    from pygeoml200 import plot_hpge_mass_comparison
+
+    ax = plot_hpge_mass_comparison(public_geometry=True)
+    assert len(ax.get_lines()) > 0


### PR DESCRIPTION
## Summary

Makes `plot_hpge_mass_comparison` produce a real, non-empty comparison for the public testdata geometry (the one built with `core.construct(public_geometry=True)`), so downstream tooling (e.g. legend-simflow) can render it without a LEGEND metadata git checkout. Previously it always required real metadata and produced an empty plot for public geometries.

## Changes

- **`hpge_mass_check.py`**: fall back to `PublicMetadataProxy` (mirroring `core.construct`) when the geometry is public, selected via `config["public_geom"]` or a new `public_geometry` keyword. The real-metadata path is unchanged (still loads `LegendMetadata`, still raises if it cannot). The existing "missing enrichment falls back to a dummy value" branch now gets exercised by the public path (the proxy sets `enrichment.val = None` for P-type detectors).
- **`configs/dummy_geom/{V,P,C,B}99000A.json`**: add `production.mass_in_g`, set a few percent off the mass `make_hpge` computes from each template, so `(MC - measured) / measured` is small, finite and visibly non-zero. Also give the templates realistic `Mirion`/`Ortec` manufacturers (instead of `"Test"`) so both manufacturer legend groups render.

| template | computed mass (g) | `mass_in_g` | rel. diff | manufacturer |
|---|---|---|---|---|
| V99000A | 1245.8 | 1220.0 | +2.1% | Mirion |
| P99000A |  821.4 |  835.0 | -1.6% | Ortec |
| C99000A | 2140.2 | 2100.0 | +1.9% | Mirion |
| B99000A |  849.5 |  860.0 | -1.2% | Ortec |

## Tests

- New `tests/test_hpge_mass.py` asserts the public path (`{"public_geom": True}` and the `public_geometry=True` keyword) yields plotted lines with finite, non-zero y-values without a metadata checkout and without raising `InvalidGitRepositoryError`.
- pre-commit and the new tests pass locally.