### PR TITLE
Fix reflective surface issue in watertank

### DIFF
--- a/src/pygeoml200/core.py
+++ b/src/pygeoml200/core.py
@@ -87,7 +87,7 @@ def construct(
         )  # -153
         tank_z_displacement = -cryo_z_displacement
 
-        water_lv, _ = watertank.insert_muon_veto(
+        water_lv, water_pv, _ = watertank.insert_muon_veto(
             reg,
             world_lv,
             tank_z_displacement,
@@ -99,6 +99,11 @@ def construct(
     # Create basic structure with argon and cryostat.
     cryostat_lv = cryo.construct_cryostat(mats.metal_steel, reg)
     cryostat_pv = cryo.place_cryostat(cryostat_lv, cryo_parent, cryo_z_displacement, reg)
+
+    if "watertank" in assemblies:
+        geant4.BorderSurface(
+            "water_cryo_surface", water_pv, cryostat_pv, mats.surfaces.vm2000_reflective_border, reg
+        )
 
     argon_z_displacement = 0  # center argon in cryostat
     lar_lv, lar_neck_height = cryo.construct_argon(mats.liquidargon, reg)

--- a/src/pygeoml200/materials/surfaces.py
+++ b/src/pygeoml200/materials/surfaces.py
@@ -198,9 +198,9 @@ class OpticalSurfaceRegistry:
         return _lar_to_pen
 
     @cached_property
-    def vm2000_reflective_skin(self) -> g4.solid.OpticalSurface:
+    def vm2000_reflective_border(self) -> g4.solid.OpticalSurface:
         """Reflective surface for VM2000."""
-        _vm2000_reflective_skin = g4.solid.OpticalSurface(
+        _vm2000_reflective_border = g4.solid.OpticalSurface(
             name="water_tank_foil_surface",
             finish="polished",
             model="unified",
@@ -209,9 +209,9 @@ class OpticalSurfaceRegistry:
             registry=self.g4_registry,
         )
 
-        pygeomoptics.vm2000.pyg4_vm2000_attach_reflectivity(_vm2000_reflective_skin, self.g4_registry)
+        pygeomoptics.vm2000.pyg4_vm2000_attach_reflectivity(_vm2000_reflective_border, self.g4_registry)
 
-        return _vm2000_reflective_skin
+        return _vm2000_reflective_border
 
     @cached_property
     def vm2000_water_border(self) -> g4.solid.OpticalSurface:

--- a/src/pygeoml200/watertank.py
+++ b/src/pygeoml200/watertank.py
@@ -533,8 +533,6 @@ def insert_vm2000(
         g4.BorderSurface(name + "_water_border_surface", pv, water_pv, surfaces.vm2000_water_border, reg)
         # water -> VM2000
         g4.BorderSurface("water_" + name + "_border_surface", water_pv, pv, surfaces.vm2000_water_border, reg)
-        # Then the reflection happens at the back of the VM2000 and the WLS happens during transport through the VM2000.
-        g4.SkinSurface(name + "_skin_surface", pv.logicalVolume, surfaces.vm2000_reflective_skin, reg)
 
     _vm2000_surfaces(pillbox_outer_reflection_foil_tube_pv)
     _vm2000_surfaces(pillbox_inner_reflection_foil_tube_pv)
@@ -931,18 +929,18 @@ def insert_muon_veto(
     mats: materials.OpticalMaterialRegistry,
 ):
     water_tank_lv = construct_tank(reg, "G4_STAINLESS-STEEL")
-    place_tank(reg, water_tank_lv, world_lv, tank_z_displacement)
+    water_tank_pv = place_tank(reg, water_tank_lv, world_lv, tank_z_displacement)
 
     water_lv = construct_water(reg, mats.water)
     water_pv = place_water(reg, water_lv, water_tank_lv)
 
-    air_buffer_lv = construct_air_buffer(reg, "G4_AIR")
+    air_buffer_lv = construct_air_buffer(reg, mats.nitrogen_air)
     place_air_buffer(reg, air_buffer_lv, water_lv)
 
     pillbox_lv, manhole_pillbox, manhole_rotation, manhole_offset = construct_pillbox(
         reg, "G4_STAINLESS-STEEL"
     )
-    place_pillbox(reg, pillbox_lv, water_lv)
+    pillbox_pv = place_pillbox(reg, pillbox_lv, water_lv)
 
     insert_vm2000(
         reg,
@@ -956,6 +954,17 @@ def insert_muon_veto(
         cryo_z_displacement,
     )
 
+    # The boundary VM2000 <--> Water is transparent, so we need a skinsurface that reflects
+    # the photons at the water --> steel boundaries
+    # Optical path: Water --> VM2000 --> Water --> Reflection at this surface --> Water --> VM2000 --> Water
+    g4.BorderSurface(
+        "water_tank_surface", water_pv, water_tank_pv, mats.surfaces.vm2000_reflective_border, reg
+    )
+    g4.BorderSurface(
+        "water_pillbox_surface", water_pv, pillbox_pv, mats.surfaces.vm2000_reflective_border, reg
+    )
+    # The water -> Cryo surface has to be in core.py
+
     insert_pmts(
         reg,
         "G4_STAINLESS-STEEL",
@@ -967,4 +976,4 @@ def insert_muon_veto(
         mats.acryl,
         mats.borosilicate,
     )
-    return water_lv, water_tank_lv
+    return water_lv, water_pv, water_tank_lv


### PR DESCRIPTION
I made a conceptual mistake in the previous implementation. I thought the optical route would be Water --> VM2000 --> Steel, so the skinsurface would apply on the back and not the bordersurface. 

The reality is: Water --> VM2000 --> Water --> Steel.

So this PR applies Bordersurfaces to all relevant Water --> Steel surfaces to accommodate this. The new optical route will be:

Water --> VM2000 --> Water --> Reflected at steel --> Water --> VM2000 --> Water

This PR will additionally also change the Air buffer above the water and give it optical properties, such that it can do fresnel. (Requires a new pygeomtools change) I did some tests to ensure the reflection properties work fine now. The steel surfaces reflect at 95% as expected, the air_buffer has around 30% reflection. In my tests, i tracked the optical path of 10 000 individual photons. 

It might be reasonable to re-visit these tests, as i found some very odd rare cases (like a reflection at a "water_pv --> gaseous_argon" boundary that should not exist).

I so far also only validated that the reflection does what i want it to (the change this PR does).

It seems that the WLS of VM2000 is a factor 10 lower than expected, but i need to do more tests. Also the optical path of Photon -> PMT-acryl --> PMT-air --> PMT-Borosilicate --> PMT-cathode needs more validation.

But anyways, i am on vacation now